### PR TITLE
Debug liquid glass rendering on iPhone 16e

### DIFF
--- a/Routines/Views/RoutineCardView.swift
+++ b/Routines/Views/RoutineCardView.swift
@@ -12,7 +12,8 @@ struct RoutineCardView: View {
     var routine: Routine
     
     var body: some View {
-        VStack {
+        // Core card content
+        let content = VStack {
             HStack{
                 VStack {
                     HStack {
@@ -37,8 +38,21 @@ struct RoutineCardView: View {
                 Text("\(routine.timeToString())")
                 Image(systemName: "clock")
             }
-            .padding(.leading)
-            .padding(.trailing)
+            .padding(.horizontal)
+        }
+        .padding()
+
+        Group {
+            if #available(iOS 18.0, *) {
+                content
+                    .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            } else {
+                content
+                    .background(
+                        .ultraThinMaterial,
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    )
+            }
         }
     }
 }


### PR DESCRIPTION
Add iOS 18 `glassBackgroundEffect` to `RoutineCardView` with a fallback to fix Liquid Glass not appearing on iPhone 16e (STY-44).

---
Linear Issue: [STY-44](https://linear.app/stygian-tech/issue/STY-44/iphone-16e-not-showing-liquid-glass)

<a href="https://cursor.com/background-agent?bcId=bc-2dcf444c-d7e4-45e7-a5c1-079b15e27363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2dcf444c-d7e4-45e7-a5c1-079b15e27363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

