### PR TITLE
Iphone 16e liquid glass

### DIFF
--- a/Routines/Views/RoutineListContent.swift
+++ b/Routines/Views/RoutineListContent.swift
@@ -35,7 +35,14 @@ struct RoutineListContent: View {
                 NavigationLink(value: routine.id) {
                     RoutineCardView(routine: routine)
                 }
-                .listRowBackground(.liquidGlass)
+                .listRowBackground {
+                    if #available(iOS 18.0, *) {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.liquidGlass)
+                    } else {
+                        Color.clear
+                    }
+                }
                 .accessibilityLabel(Text(routine.name))
                 .accessibilityHint(Text("Opens routine"))
                 .contextMenu {

--- a/Routines/Views/RoutineListContent.swift
+++ b/Routines/Views/RoutineListContent.swift
@@ -35,6 +35,7 @@ struct RoutineListContent: View {
                 NavigationLink(value: routine.id) {
                     RoutineCardView(routine: routine)
                 }
+                .listRowBackground(.liquidGlass)
                 .accessibilityLabel(Text(routine.name))
                 .accessibilityHint(Text("Opens routine"))
                 .contextMenu {

--- a/Routines/Views/StepListView.swift
+++ b/Routines/Views/StepListView.swift
@@ -27,6 +27,7 @@ struct StepListView: View {
                         editingStepIndex: $editingStepIndex,
                         showHiddenSteps: $showHiddenSteps
                     )
+                    .listRowBackground(.liquidGlass)
                 }
             }
             .onMove(perform: moveItem)

--- a/Routines/Views/StepListView.swift
+++ b/Routines/Views/StepListView.swift
@@ -27,7 +27,14 @@ struct StepListView: View {
                         editingStepIndex: $editingStepIndex,
                         showHiddenSteps: $showHiddenSteps
                     )
-                    .listRowBackground(.liquidGlass)
+                    .listRowBackground {
+                        if #available(iOS 18.0, *) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(.liquidGlass)
+                        } else {
+                            Color.clear
+                        }
+                    }
                 }
             }
             .onMove(perform: moveItem)


### PR DESCRIPTION
Add iOS 18 Liquid Glass styling to list rows to resolve missing elements on iPhone 16e.

---
Linear Issue: [STY-44](https://linear.app/stygian-tech/issue/STY-44/iphone-16e-not-showing-liquid-glass)

<p><a href="https://cursor.com/background-agent?bcId=bc-cdabcb92-46d3-4d31-a0c9-68d68202068d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdabcb92-46d3-4d31-a0c9-68d68202068d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

