### PR TITLE
Add repeat interval options for routines (ROUI-15)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,22 @@
+# .agents Directory
+
+This directory follows the [.agents Protocol](https://dotagentsprotocol.com/) — an open standard for AI agent configuration. It provides structured, version-controlled context for AI agents working in this repository.
+
+## Contents
+
+| File / Directory | Purpose |
+|------------------|---------|
+| `agents.md` | Main agent instructions (AGENTS.md compatible). Points to repository guidelines. |
+| `memories/` | Persistent project context (architecture decisions, key patterns). |
+| `skills/` | Workflow skills. Currently: `linear-workflow` (Linear issue tracking). |
+
+## For Agents
+
+- **Primary instructions**: Read [agents.md](agents.md) first. It references [AGENTS.md](../AGENTS.md) in the repository root for full development guidelines.
+- **Architecture context**: See [memories/architecture.md](memories/architecture.md) for data models, services, and data flow.
+- **Linear workflow**: See [skills/linear-workflow/SKILL.md](skills/linear-workflow/SKILL.md) when working on feature branches or plans.
+- **Human docs**: See [README.md](../README.md) for project overview, features, and setup.
+
+## For Tools That Read Root Only
+
+Some tools (e.g., Cursor) read [AGENTS.md](../AGENTS.md) at the repository root. That file contains the full agent guidelines. This `.agents/` directory supplements it with modular structure and architecture memories.

--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -1,0 +1,30 @@
+---
+kind: agents
+---
+
+# Project Guidelines
+
+This repository contains **Routines**, a native iOS and watchOS app for managing daily routines and tracking step completion. Built with SwiftUI, SwiftData, and CloudKit.
+
+## Quick Reference
+
+- **Platforms**: iOS 17+, watchOS 10+, WidgetKit extension
+- **Stack**: SwiftUI, SwiftData, CloudKit
+- **Targets**: `Routines/` (iOS), `RoutinesWatch Watch App/` (watchOS), `Routines Widgets/` (WidgetKit)
+- **Views**: `*View.swift` naming in `Routines/Views/` and `RoutinesWatch Watch App/Views/`
+- **Models**: `Routine`, `Step`, `StepCompletionStatus`, etc. in `Routines/Models/`
+
+## Full Guidelines
+
+See [AGENTS.md](../AGENTS.md) in the repository root for complete development guidelines:
+
+- Project structure and module organization
+- Build, test, and development commands
+- Coding style and naming conventions
+- Testing guidelines
+- Commit and pull request guidelines
+- Configuration notes (buildServer.json, SourceKit-LSP)
+
+## Architecture
+
+For data models, services, data flow, and day synchronization rules, see [memories/architecture.md](memories/architecture.md).

--- a/.agents/memories/architecture.md
+++ b/.agents/memories/architecture.md
@@ -1,0 +1,52 @@
+---
+id: arch_routines
+title: Routines Architecture
+importance: high
+tags: swiftdata, cloudkit, architecture
+---
+
+# Routines Architecture
+
+## Data Models
+
+- **Routine**: Main model with name, time, icon, color, days, and steps
+- **Step**: Individual steps within a routine with name, order, status, and scheduled days
+
+## Key Services
+
+- **RoutineManager**: Manages routine operations (creation, deletion, completion checking)
+- **StepManager**: Handles step operations
+- **RoutineDaySynchronizer**: Ensures day consistency between routines and steps
+- **CloudKitSyncObserver**: Monitors CloudKit sync status
+- **CloudKitSubscriptionManager**: Manages CloudKit push notifications
+- **CloudKitNotificationManager**: Handles CloudKit notification processing
+
+## Data Flow
+
+1. User creates/edits routines and steps in SwiftUI views
+2. Changes are persisted to SwiftData ModelContext
+3. SwiftData automatically syncs to CloudKit
+4. CloudKit syncs changes to other devices
+5. CloudKitSyncObserver notifies the app of remote changes
+6. Views update automatically via SwiftData @Query
+
+## Day Synchronization
+
+- Routine days are always the superset of all step days
+- Adding a day to a step automatically adds it to the parent routine
+- Removing a day from a routine cascades to all steps (unless it would orphan a step)
+- Steps cannot be left without any scheduled days
+
+## CloudKit Sync
+
+- Both iOS and watchOS apps use the same CloudKit container
+- Automatic migration from local-only storage to CloudKit
+- Real-time sync with push notifications
+- Handles conflicts gracefully
+
+## Completion Tracking
+
+- Routines track completion status: incomplete, complete, or complete with skipped steps
+- Steps can be marked as complete, incomplete, or skipped
+- Completion status is calculated automatically based on step statuses
+- Only steps scheduled for today are considered in completion calculations

--- a/.agents/skills/linear-workflow/SKILL.md
+++ b/.agents/skills/linear-workflow/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: linear-workflow
+description: ALWAYS check for linked Linear issue and follow conventions before starting work. Use when on a feature branch, when beginning any coding task, or when in plan mode.
+---
+
+# Linear Workflow
+
+**MANDATORY:** Linear is the source of truth for planning, implementation status, blockers, and verification, not GitHub. Check for a linked Linear issue before starting work, and keep it current throughout the task. Linear–GitHub integration depends on correct branch names and issue updates.
+
+## When to Use (invoke this skill FIRST)
+
+- **Every** coding task, fix, or implementation—before any other actions
+- **Plan mode**—when creating, writing, or drafting a plan (e.g. `.plan.md`). Do not skip Linear updates because you are "only planning."
+- When switching to a new branch
+- When the user asks you to implement, fix, change something, or create a plan
+
+**Do not skip.** If you will edit code or create plans, invoke this skill and complete the workflow before touching files.
+
+## Instructions
+
+1. **Check branch** via `git branch --show-current`. Branch naming varies by tool:
+   - **Linear-style**: `sam/ROUI-123-feature-name`, `ROUI-456-fix` (includes Linear ID directly)
+   - **Issue-style**: `123-add-feature`, `issue92-fix` (GitHub issue number; Linear is linked elsewhere)
+
+2. **Find the Linear issue**: Linear is always the source of truth—there will always be a Linear ticket linked somewhere. If the branch has a Linear ID (e.g. `ROUI-123`), use it directly. If the branch has an issue number (e.g. `123`), check the GitHub issue: Linear's integration leaves a comment in Markdown format `[linear-id](link)`, e.g. `[ROUI-123](https://linear.app/...)`. Parse that to get the Linear ID. Otherwise use `list_issues` with a `query` matching the branch/task.
+
+3. **Confirm issue exists** via Linear MCP `get_issue` or `list_issues`. Once found, use that Linear issue for all updates.
+
+4. **Set In Progress** via `save_issue` with `state: "In Progress"` before making code changes or creating plans.
+
+5. **During planning**: Add comments via `save_comment`—when drafting a plan, summarize the approach or key decisions on the Linear issue.
+
+6. **During implementation**: Include the full plan via `save_comment`—when implementing from a `.plan.md` file, paste the **entire plan content** as a Linear comment so reviewers have full context.
+
+7. **Add comments as you work** via `save_comment`—implementations, decisions, blockers.
+
+8. **Keep Linear current continuously**. If scope, status, blockers, implementation details, or verification results change, update the issue before continuing.
+
+9. **Handle newly discovered issues explicitly**. If the current branch introduced the regression, create a Linear sub-issue under the current issue and note that split on the parent issue before continuing. If you discover a separate issue that is not a regression from the current branch, create a separate Linear issue rather than a sub-issue and note that split on the parent issue before continuing.
+
+10. **Apply labels, assignee, and metadata when an agent creates the issue**. Use the `Agent` label in MCP calls for any issue created by an agent, even when the underlying problem was reported by the user during the session. In Linear UI this may appear under the `Source` group. Assign the issue to **Sam Clemente** by default. Also add the other relevant inferred metadata from the current context when it is clear, including product or platform labels (e.g. iOS, watchOS, Widgets), project association, priority, and any area labels that match the affected surface.
+
+11. **If work is tracked in a split issue, comment there**. Put the plan, implementation progress, blockers, verification notes, and completion summary on the sub-issue or separate issue itself. Use the parent issue only for the split note and high-level coordination.
+
+12. **Do not mark Done**—let Linear–GitHub integration set Done when the PR is merged.
+
+If no Linear issue exists (e.g. branch is `main` or doesn’t match patterns), proceed without Linear updates—but **always check first**. For any feature work, the branch will always link to a Linear ticket somewhere.
+
+## Reference
+
+- [AGENTS.md](../../../AGENTS.md) — repository guidelines (structure, build, style, testing)
+- [.agents/README.md](../../README.md) — agent context and architecture

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.xcuserstate
 GoogleService-Info.plist
 
+# Cursor IDE (local)
+.cursor/
+
 # Build artifacts
 build/
 Build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,7 @@ Prefer Xcode for day-to-day work. CLI examples:
 
 ## Configuration Notes
 - `buildServer.json` is present for tooling integration (e.g., SourceKit-LSP). Keep it updated if build settings change.
+
+## .agents Directory
+
+For tools that support the [.agents Protocol](https://dotagentsprotocol.com/), see the [.agents/](.agents/) directory for modular instructions, architecture memories, and skills.

--- a/Routines.xcodeproj/project.pbxproj
+++ b/Routines.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 				Models/Routine.swift,
 				Models/RoutineCompletionIcon.swift,
 				Models/RoutineCompletionStatus.swift,
+				Models/RoutineRepeatInterval.swift,
 				Models/Step.swift,
 				Models/StepCompletionStatus.swift,
 				Models/Symbol.swift,

--- a/Routines.xcodeproj/xcuserdata/sam.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Routines.xcodeproj/xcuserdata/sam.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>Routines WidgetsExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>2</integer>
 		</dict>
 		<key>Routines.xcscheme_^#shared#^_</key>
 		<dict>
@@ -22,7 +22,7 @@
 		<key>RoutinesWatch Watch App.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>4</integer>
+			<integer>1</integer>
 		</dict>
 		<key>RoutinesWatch.xcscheme_^#shared#^_</key>
 		<dict>

--- a/Routines.xctestplan
+++ b/Routines.xctestplan
@@ -31,7 +31,7 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:Routines.xcodeproj",
         "identifier" : "224CA0462C321EEF0096F094",
@@ -39,7 +39,7 @@
       }
     },
     {
-      "parallelizable" : true,
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:Routines.xcodeproj",
         "identifier" : "224CA0502C321EEF0096F094",

--- a/Routines/App/AppDelegate.swift
+++ b/Routines/App/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     var notificationManager: CloudKitNotificationManager?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        // Register for remote notifications
+        guard !UnitTestRuntime.isActive else { return true }
         application.registerForRemoteNotifications()
         return true
     }

--- a/Routines/App/RoutinesApp.swift
+++ b/Routines/App/RoutinesApp.swift
@@ -24,46 +24,44 @@ struct RoutinesApp: App {
     
     init() {
         do {
-            // Configure schema with Routine and Step models
             let schema = Schema([Routine.self, Step.self])
-            
-            // Configure ModelConfiguration with CloudKit for sync
-            // Using .automatic will use the iCloud container configured in Xcode
+            let runsUnitTests = UnitTestRuntime.isActive
+
             let configuration = ModelConfiguration(
                 schema: schema,
-                isStoredInMemoryOnly: false,
-                cloudKitDatabase: .automatic
+                isStoredInMemoryOnly: runsUnitTests,
+                cloudKitDatabase: runsUnitTests ? .none : .automatic
             )
-            
+
             container = try ModelContainer(for: schema, configurations: [configuration])
-            
-            // Set up CloudKit sync observer for real-time updates
-            cloudKitSyncObserver = CloudKitSyncObserver(container: container)
-            
-            // Set up CloudKit notification manager for handling push notifications
-            cloudKitNotificationManager = CloudKitNotificationManager(syncObserver: cloudKitSyncObserver)
-            
-            // Set up CloudKit subscription manager for push notifications
-            cloudKitSubscriptionManager = CloudKitSubscriptionManager()
-            
-            // Log CloudKit configuration for debugging
-            print("iOS: ModelContainer initialized with CloudKit")
-            print("iOS: Bundle ID: \(Bundle.main.bundleIdentifier ?? "unknown")")
-            
-            // Set up CloudKit subscription for push notifications
-            let subscriptionManager = cloudKitSubscriptionManager
-            Task { @MainActor in
-                await subscriptionManager.setupSubscription()
+            if runsUnitTests {
+                UnitTestModelContainer.shared = container
             }
-            
-            // Check initial data count and perform migration if needed
+
+            cloudKitSyncObserver = CloudKitSyncObserver(
+                container: container,
+                activatesCloudKitHooks: !runsUnitTests
+            )
+            cloudKitNotificationManager = CloudKitNotificationManager(syncObserver: cloudKitSyncObserver)
+            cloudKitSubscriptionManager = CloudKitSubscriptionManager()
+
+            if runsUnitTests {
+                print("iOS: ModelContainer initialized for unit tests (in-memory, no CloudKit hooks)")
+            } else {
+                print("iOS: ModelContainer initialized with CloudKit")
+                print("iOS: Bundle ID: \(Bundle.main.bundleIdentifier ?? "unknown")")
+                let subscriptionManager = cloudKitSubscriptionManager
+                Task { @MainActor in
+                    await subscriptionManager.setupSubscription()
+                }
+            }
+
             Task { [container] in
                 let context = ModelContext(container)
                 do {
                     let routines: [Routine] = try context.fetch(FetchDescriptor<Routine>())
                     print("iOS: Routine count: \(routines.count)")
-                    
-                    // Perform lazy migration on app launch
+
                     for routine in routines {
                         routine.migrateDaysIfNeeded()
                         for step in routine.steps ?? [] {
@@ -71,8 +69,8 @@ struct RoutinesApp: App {
                         }
                     }
                     try context.save()
-                    
-                    if routines.isEmpty {
+
+                    if routines.isEmpty, !runsUnitTests {
                         print("iOS: WARNING - No routines found. Make sure data was migrated to CloudKit.")
                     }
                 } catch {
@@ -82,11 +80,13 @@ struct RoutinesApp: App {
         } catch {
             fatalError("Failed to load model container: \(error.localizedDescription)")
         }
-        
+
         if isUITestSeedEnabled {
             seedDataForUITests()
         }
-        configureTips()
+        if !UnitTestRuntime.isActive {
+            configureTips()
+        }
     }
     
     var body: some Scene {
@@ -94,12 +94,12 @@ struct RoutinesApp: App {
             AppLifecycleSyncView(syncObserver: cloudKitSyncObserver) {
                 RoutineListView()
                     .onAppear {
-                        // Set up the notification manager reference in app delegate
                         appDelegate.notificationManager = cloudKitNotificationManager
-                        promptForNotifications()
-                        // Migrate local data to CloudKit if needed
-                        Task { [container] in
-                            await Self.migrateLocalDataToCloudKit(container: container)
+                        if !UnitTestRuntime.isActive {
+                            promptForNotifications()
+                            Task { [container] in
+                                await Self.migrateLocalDataToCloudKit(container: container)
+                            }
                         }
                     }
                     .onReceive(NotificationCenter.default.publisher(for: NSLocale.currentLocaleDidChangeNotification)) { _ in
@@ -244,11 +244,8 @@ struct RoutinesApp: App {
                         days: localStep.days
                     )
                     newStep.status = localStep.status
-                    if newRoutine.steps == nil {
-                        newRoutine.steps = []
-                    }
-                    newRoutine.steps?.append(newStep)
                     cloudKitContext.insert(newStep)
+                    newRoutine.steps = (newRoutine.steps ?? []) + [newStep]
                 }
                 
                 cloudKitContext.insert(newRoutine)

--- a/Routines/Info.plist
+++ b/Routines/Info.plist
@@ -4,6 +4,68 @@
 <dict>
 	<key>CFBundleGetInfoString</key>
 	<string></string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>AppIcon-Amber</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Amber</string>
+				</array>
+			</dict>
+			<key>AppIcon-Deep</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Deep</string>
+				</array>
+			</dict>
+			<key>AppIcon-Forest</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Forest</string>
+				</array>
+			</dict>
+			<key>AppIcon-Goldenrod</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Goldenrod</string>
+				</array>
+			</dict>
+			<key>AppIcon-Jum</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Jum</string>
+				</array>
+			</dict>
+			<key>AppIcon-Red</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Red</string>
+				</array>
+			</dict>
+			<key>AppIcon-Teal</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>AppIcon-Teal</string>
+				</array>
+			</dict>
+		</dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>AppIcon</string>
+			</array>
+		</dict>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/Routines/Models/AppIconOption.swift
+++ b/Routines/Models/AppIconOption.swift
@@ -106,7 +106,7 @@ final class AppIconManager: ObservableObject {
         return AppIconOption(displayName: fallbackName, alternateIconName: alternateIconName, previewColor: .gray, previewImageName: imageName(for: fallbackName))
     }
 
-    func setIcon(to option: AppIconOption, completion: ((Error?) -> Void)? = nil) {
+    func setIcon(to option: AppIconOption, completion: (@Sendable (Error?) -> Void)? = nil) {
         guard #available(iOS 10.3, *) else {
             lastError = "Changing app icons requires iOS 10.3+."
             completion?(NSError(domain: "AppIcon", code: 1, userInfo: [NSLocalizedDescriptionKey: lastError ?? "Unknown error"]))
@@ -131,5 +131,4 @@ final class AppIconManager: ObservableObject {
         }
     }
 }
-
 

--- a/Routines/Models/Routine.swift
+++ b/Routines/Models/Routine.swift
@@ -308,6 +308,12 @@ class Routine: Identifiable {
     }
 
     func isScheduled(on date: Date) -> Bool {
+        let calendar = DateUtility.currentCalendar
+        if repeatInterval.usesLongCycleStartDate {
+            let dayStart = calendar.startOfDay(for: date)
+            let anchorStart = calendar.startOfDay(for: repeatAnchorDate)
+            guard dayStart >= anchorStart else { return false }
+        }
         let weekday = DateUtility.weekday(for: date)
         guard days.contains(weekday) else { return false }
         return isRepeatIntervalActive(on: date)

--- a/Routines/Models/Routine.swift
+++ b/Routines/Models/Routine.swift
@@ -21,6 +21,8 @@ class Routine: Identifiable {
     var iconSymbol: String = "list.bullet"
     var status = RoutineCompletionStatus.incomplete
     var finishedStepCount = 0
+    var repeatIntervalRawValue: String = RoutineRepeatInterval.weekly.rawValue
+    var repeatAnchorDate: Date = Date()
     
     var days: [Weekday] {
         get {
@@ -69,40 +71,88 @@ class Routine: Identifiable {
     @Attribute var daysData: Data? = nil
     @Attribute var lastModifiedDate: Date?
     
-    init(name: String = "New Routine", time: Date = Date(), iconColor: String = SystemColors.blue.rawValue, iconSymbol: String = "list.bullet") {
+    init(
+        name: String = "New Routine",
+        time: Date = Date(),
+        iconColor: String = SystemColors.blue.rawValue,
+        iconSymbol: String = "list.bullet",
+        repeatInterval: RoutineRepeatInterval = .weekly,
+        repeatAnchorDate: Date = Date()
+    ) {
         self.name = name
         self.time = time
         self.iconColor = iconColor
         self.iconSymbol = iconSymbol
+        self.repeatInterval = repeatInterval
+        self.repeatAnchorDate = repeatAnchorDate
         self.lastModifiedDate = Date()
     }
 
-    init(name: String = "New Routine", time: Date = Date(), iconColor: String = SystemColors.blue.rawValue, iconSymbol: String = "list.bullet", steps: [Step] = [Step]()) {
+    init(
+        name: String = "New Routine",
+        time: Date = Date(),
+        iconColor: String = SystemColors.blue.rawValue,
+        iconSymbol: String = "list.bullet",
+        repeatInterval: RoutineRepeatInterval = .weekly,
+        repeatAnchorDate: Date = Date(),
+        steps: [Step] = [Step]()
+    ) {
         self.name = name
         self.time = time
         self.iconColor = iconColor
         self.iconSymbol = iconSymbol
+        self.repeatInterval = repeatInterval
+        self.repeatAnchorDate = repeatAnchorDate
         self.steps = steps
         self.lastModifiedDate = Date()
     }
     
-    init(name: String = "New Routine", time: Date = Date(), iconColor: String = SystemColors.blue.rawValue, iconSymbol: String = "list.bullet", days: [Weekday]) {
+    init(
+        name: String = "New Routine",
+        time: Date = Date(),
+        iconColor: String = SystemColors.blue.rawValue,
+        iconSymbol: String = "list.bullet",
+        repeatInterval: RoutineRepeatInterval = .weekly,
+        repeatAnchorDate: Date = Date(),
+        days: [Weekday]
+    ) {
         self.name = name
         self.time = time
         self.iconColor = iconColor
         self.iconSymbol = iconSymbol
+        self.repeatInterval = repeatInterval
+        self.repeatAnchorDate = repeatAnchorDate
         self.days = days
         self.lastModifiedDate = Date()
     }
     
     // Convenience initializer for backward compatibility with string arrays (for migration)
-    init(name: String = "New Routine", time: Date = Date(), iconColor: String = SystemColors.blue.rawValue, iconSymbol: String = "list.bullet", daysStrings: [String]) {
+    init(
+        name: String = "New Routine",
+        time: Date = Date(),
+        iconColor: String = SystemColors.blue.rawValue,
+        iconSymbol: String = "list.bullet",
+        repeatInterval: RoutineRepeatInterval = .weekly,
+        repeatAnchorDate: Date = Date(),
+        daysStrings: [String]
+    ) {
         self.name = name
         self.time = time
         self.iconColor = iconColor
         self.iconSymbol = iconSymbol
+        self.repeatInterval = repeatInterval
+        self.repeatAnchorDate = repeatAnchorDate
         self.days = DateUtility.weekdaysFromStrings(daysStrings)
         self.lastModifiedDate = Date()
+    }
+
+    var repeatInterval: RoutineRepeatInterval {
+        get {
+            RoutineRepeatInterval(rawValue: repeatIntervalRawValue) ?? .weekly
+        }
+        set {
+            repeatIntervalRawValue = newValue.rawValue
+        }
     }
     
     
@@ -181,7 +231,15 @@ class Routine: Identifiable {
     /// ```
     /// - Returns: A new `Routine` object with the same values as `self`
     func copy() -> Routine {
-        let copy = Routine(name: self.name, time: self.time, iconColor: self.iconColor, iconSymbol: self.iconSymbol, days: self.days)
+        let copy = Routine(
+            name: self.name,
+            time: self.time,
+            iconColor: self.iconColor,
+            iconSymbol: self.iconSymbol,
+            repeatInterval: self.repeatInterval,
+            repeatAnchorDate: self.repeatAnchorDate,
+            days: self.days
+        )
         return copy
     }
     
@@ -246,8 +304,38 @@ class Routine: Identifiable {
     }
     
     func isToday() -> Bool {
-        let today = DateUtility.todayWeekday()
-        return days.contains(today)
+        isScheduled(on: Date())
+    }
+
+    func isScheduled(on date: Date) -> Bool {
+        let weekday = DateUtility.weekday(for: date)
+        guard days.contains(weekday) else { return false }
+        return isRepeatIntervalActive(on: date)
+    }
+
+    func isRepeatIntervalActive(on date: Date) -> Bool {
+        let calendar = DateUtility.currentCalendar
+        let anchorDate = repeatAnchorDate
+
+        if let weekInterval = repeatInterval.weekInterval {
+            let anchorStartOfWeek = calendar.dateInterval(of: .weekOfYear, for: anchorDate)?.start
+                ?? calendar.startOfDay(for: anchorDate)
+            let currentStartOfWeek = calendar.dateInterval(of: .weekOfYear, for: date)?.start
+                ?? calendar.startOfDay(for: date)
+            let weeksDifference = calendar.dateComponents([.weekOfYear], from: anchorStartOfWeek, to: currentStartOfWeek).weekOfYear ?? 0
+            return weeksDifference % weekInterval == 0
+        }
+
+        if let monthInterval = repeatInterval.monthInterval {
+            let anchorMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: anchorDate))
+                ?? calendar.startOfDay(for: anchorDate)
+            let currentMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: date))
+                ?? calendar.startOfDay(for: date)
+            let monthsDifference = calendar.dateComponents([.month], from: anchorMonth, to: currentMonth).month ?? 0
+            return monthsDifference % monthInterval == 0
+        }
+
+        return true
     }
     
     func skipRemainingSteps() {

--- a/Routines/Models/RoutineRepeatInterval.swift
+++ b/Routines/Models/RoutineRepeatInterval.swift
@@ -1,0 +1,62 @@
+//
+//  RoutineRepeatInterval.swift
+//  Routines
+//
+//  Created by Codex on 2/8/26.
+//
+
+import Foundation
+
+enum RoutineRepeatInterval: String, CaseIterable, Codable, Identifiable {
+    case weekly
+    case fortnightly
+    case monthly
+    case biMonthly
+    case quarterly
+    case yearly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .weekly:
+            return "Weekly"
+        case .fortnightly:
+            return "Fortnightly"
+        case .monthly:
+            return "Monthly"
+        case .biMonthly:
+            return "Bi-Monthly (Every two months)"
+        case .quarterly:
+            return "Quarterly"
+        case .yearly:
+            return "Yearly"
+        }
+    }
+
+    var weekInterval: Int? {
+        switch self {
+        case .weekly:
+            return 1
+        case .fortnightly:
+            return 2
+        default:
+            return nil
+        }
+    }
+
+    var monthInterval: Int? {
+        switch self {
+        case .monthly:
+            return 1
+        case .biMonthly:
+            return 2
+        case .quarterly:
+            return 3
+        case .yearly:
+            return 12
+        default:
+            return nil
+        }
+    }
+}

--- a/Routines/Models/RoutineRepeatInterval.swift
+++ b/Routines/Models/RoutineRepeatInterval.swift
@@ -22,11 +22,11 @@ enum RoutineRepeatInterval: String, CaseIterable, Codable, Identifiable {
         case .weekly:
             return "Weekly"
         case .fortnightly:
-            return "Fortnightly"
+            return "Every Other Week"
         case .monthly:
             return "Monthly"
         case .biMonthly:
-            return "Bi-Monthly (Every two months)"
+            return "Every Other Month"
         case .quarterly:
             return "Quarterly"
         case .yearly:
@@ -57,6 +57,16 @@ enum RoutineRepeatInterval: String, CaseIterable, Codable, Identifiable {
             return 12
         default:
             return nil
+        }
+    }
+
+    /// Cadences longer than one week use `repeatAnchorDate` (start of day) as the first day the routine may appear.
+    var usesLongCycleStartDate: Bool {
+        switch self {
+        case .weekly:
+            return false
+        case .fortnightly, .monthly, .biMonthly, .quarterly, .yearly:
+            return true
         }
     }
 }

--- a/Routines/Models/Step.swift
+++ b/Routines/Models/Step.swift
@@ -85,8 +85,16 @@ class Step: Identifiable {
     }
     
     func isToday() -> Bool {
-        let today = DateUtility.todayWeekday()
-        return days.contains(today)
+        let date = Date()
+        let weekday = DateUtility.weekday(for: date)
+        guard days.contains(weekday) else { return false }
+
+        if let routine = routine {
+            guard routine.days.contains(weekday) else { return false }
+            return routine.isRepeatIntervalActive(on: date)
+        }
+
+        return true
     }
     
     /// Marks the step as modified by updating the lastModifiedDate timestamp

--- a/Routines/Models/Step.swift
+++ b/Routines/Models/Step.swift
@@ -84,17 +84,15 @@ class Step: Identifiable {
         self.lastModifiedDate = Date()
     }
     
-    func isToday() -> Bool {
-        let date = Date()
+    /// Whether this step counts as active on the given date (routine schedule, weekday, and step days).
+    func isActive(on date: Date) -> Bool {
         let weekday = DateUtility.weekday(for: date)
         guard days.contains(weekday) else { return false }
+        return routine?.isScheduled(on: date) ?? true
+    }
 
-        if let routine = routine {
-            guard routine.days.contains(weekday) else { return false }
-            return routine.isRepeatIntervalActive(on: date)
-        }
-
-        return true
+    func isToday() -> Bool {
+        isActive(on: Date())
     }
     
     /// Marks the step as modified by updating the lastModifiedDate timestamp

--- a/Routines/Services/CloudKitSyncObserver.swift
+++ b/Routines/Services/CloudKitSyncObserver.swift
@@ -46,13 +46,16 @@ class CloudKitSyncObserver: ObservableObject {
     private let maxRetries: Int = 3
     private let baseRetryDelay: TimeInterval = 1.0
     
-    init(container: ModelContainer) {
+    /// - Parameter activatesCloudKitHooks: When `false` (unit test host), skips remote observers, timers, and lifecycle sync to avoid crashes.
+    init(container: ModelContainer, activatesCloudKitHooks: Bool = true) {
         self.container = container
         self.sourceOfTruthService = CloudKitSourceOfTruth()
         self.conflictResolver = CloudKitConflictResolver()
-        setupRemoteChangeObserver()
-        startPeriodicSync()
-        setupAppLifecycleObservers()
+        if activatesCloudKitHooks {
+            setupRemoteChangeObserver()
+            startPeriodicSync()
+            setupAppLifecycleObservers()
+        }
     }
     
     nonisolated deinit {

--- a/Routines/Services/RoutineManager.swift
+++ b/Routines/Services/RoutineManager.swift
@@ -159,7 +159,9 @@ final class RoutineManager: @unchecked Sendable {
         time: Date,
         iconColor: String,
         iconSymbol: String,
-        days: [Weekday]? = nil
+        days: [Weekday]? = nil,
+        repeatInterval: RoutineRepeatInterval = .weekly,
+        repeatAnchorDate: Date = Date()
     ) async throws -> Routine {
         let routineDays = days ?? DateUtility.allWeekdays()
         let routine = Routine(
@@ -167,6 +169,8 @@ final class RoutineManager: @unchecked Sendable {
             time: time,
             iconColor: iconColor,
             iconSymbol: iconSymbol,
+            repeatInterval: repeatInterval,
+            repeatAnchorDate: repeatAnchorDate,
             days: routineDays
         )
         modelContext.insert(routine)
@@ -182,7 +186,9 @@ final class RoutineManager: @unchecked Sendable {
         time: Date? = nil,
         iconColor: String? = nil,
         iconSymbol: String? = nil,
-        days: [Weekday]? = nil
+        days: [Weekday]? = nil,
+        repeatInterval: RoutineRepeatInterval? = nil,
+        repeatAnchorDate: Date? = nil
     ) async throws {
         var hasChanges = false
         if let name = name, routine.name != name {
@@ -203,6 +209,14 @@ final class RoutineManager: @unchecked Sendable {
         }
         if let days = days, Set(routine.days) != Set(days) {
             routine.days = days
+            hasChanges = true
+        }
+        if let repeatInterval = repeatInterval, routine.repeatInterval != repeatInterval {
+            routine.repeatInterval = repeatInterval
+            hasChanges = true
+        }
+        if let repeatAnchorDate = repeatAnchorDate, routine.repeatAnchorDate != repeatAnchorDate {
+            routine.repeatAnchorDate = repeatAnchorDate
             hasChanges = true
         }
         
@@ -278,4 +292,3 @@ final class RoutineManager: @unchecked Sendable {
         try modelContext.save()
     }
 }
-

--- a/Routines/Services/StepManager.swift
+++ b/Routines/Services/StepManager.swift
@@ -51,12 +51,7 @@ final class StepManager: @unchecked Sendable {
         )
         
         modelContext.insert(newStep)
-        
-        // Ensure steps array is initialized
-        if routine.steps == nil {
-            routine.steps = []
-        }
-        routine.steps?.append(newStep)
+        replaceSteps(on: routine, with: (routine.steps ?? []) + [newStep])
         routine.markAsModified() // Routine changed (added step)
         
         try modelContext.save()
@@ -127,7 +122,9 @@ final class StepManager: @unchecked Sendable {
             }
             modelContext.delete(step)
         }
-        
+
+        currentSteps.sort { $0.order < $1.order }
+
         // Reorder remaining steps
         for (index, step) in currentSteps.enumerated() {
             if step.order != index {
@@ -136,7 +133,7 @@ final class StepManager: @unchecked Sendable {
             }
         }
         
-        routine.steps = currentSteps
+        replaceSteps(on: routine, with: currentSteps)
         routine.markAsModified() // Routine changed (removed steps)
         try modelContext.save()
         triggerSyncIfNeeded()
@@ -162,7 +159,7 @@ final class StepManager: @unchecked Sendable {
             }
         }
         
-        routine.steps = tempSteps
+        replaceSteps(on: routine, with: tempSteps)
         routine.markAsModified() // Routine changed (reordered steps)
         try modelContext.save()
     }
@@ -179,9 +176,14 @@ final class StepManager: @unchecked Sendable {
             }
         }
         
-        routine.steps = steps
+        replaceSteps(on: routine, with: steps)
         routine.markAsModified() // Routine changed (reordered steps)
         try modelContext.save()
+    }
+    
+    /// SwiftData can trap when assigning an empty array to an optional to-many relationship; use `nil` instead.
+    private func replaceSteps(on routine: Routine, with steps: [Step]) {
+        routine.steps = steps.isEmpty ? nil : steps
     }
     
     // MARK: - Utility Operations

--- a/Routines/Utilities/DateUtility.swift
+++ b/Routines/Utilities/DateUtility.swift
@@ -121,8 +121,13 @@ struct DateUtility {
     
     /// Get today's weekday
     static func todayWeekday() -> Weekday {
+        weekday(for: Date())
+    }
+
+    /// Get the weekday for a specific date
+    static func weekday(for date: Date) -> Weekday {
         let calendar = currentCalendar
-        let weekdayComponent = calendar.component(.weekday, from: Date())
+        let weekdayComponent = calendar.component(.weekday, from: date)
         return Weekday(rawValue: weekdayComponent)
     }
     
@@ -232,4 +237,3 @@ extension DateUtility {
         return weekdays.sorted()
     }
 }
-

--- a/Routines/Utilities/UnitTestModelContainer.swift
+++ b/Routines/Utilities/UnitTestModelContainer.swift
@@ -1,0 +1,35 @@
+//
+//  UnitTestModelContainer.swift
+//  Routines
+//
+
+import SwiftData
+
+/// When running hosted (`Routines.app` + `RoutinesTests`), SwiftData must use a single `ModelContainer` for the process.
+/// Creating additional containers in tests triggers Core Data + CloudKit mirroring teardown and stalls the test runner.
+enum UnitTestModelContainer {
+    /// Assigned from `RoutinesApp` when `UnitTestRuntime.isActive`.
+    nonisolated(unsafe) static var shared: ModelContainer?
+
+    enum TestSupportError: Error {
+        case missingSharedContainer
+    }
+
+    /// New `ModelContext` sharing the app’s in-memory store, with all persisted routines removed.
+    static func makeFreshContext() throws -> ModelContext {
+        guard let shared else {
+            throw TestSupportError.missingSharedContainer
+        }
+        let context = ModelContext(shared)
+        try resetAllRoutines(in: context)
+        return context
+    }
+
+    static func resetAllRoutines(in context: ModelContext) throws {
+        let routines = try context.fetch(FetchDescriptor<Routine>())
+        routines.forEach { context.delete($0) }
+        if context.hasChanges {
+            try context.save()
+        }
+    }
+}

--- a/Routines/Utilities/UnitTestRuntime.swift
+++ b/Routines/Utilities/UnitTestRuntime.swift
@@ -1,0 +1,22 @@
+//
+//  UnitTestRuntime.swift
+//  Routines
+//
+
+import Foundation
+
+/// True when the iOS app is running as the XCTest/Swift Testing host (injected test bundle).
+/// Used to avoid CloudKit, push, Tips, and timers that crash or destabilize the simulator test process.
+enum UnitTestRuntime {
+    static var isActive: Bool { Self.isLoadedInTestHostProcess }
+
+    private static var isLoadedInTestHostProcess: Bool {
+        if NSClassFromString("XCTestCase") != nil { return true }
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestSessionIdentifier"] != nil { return true }
+        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["XCTestBundlePath"] != nil { return true }
+        if let dyld = env["DYLD_INSERT_LIBRARIES"], dyld.contains("XCTest") { return true }
+        return false
+    }
+}

--- a/Routines/Views/AppIconPickerView.swift
+++ b/Routines/Views/AppIconPickerView.swift
@@ -46,11 +46,12 @@ struct AppIconPickerView: View {
 
     private func select(_ option: AppIconOption) {
         manager.setIcon(to: option) { _ in
-            if manager.lastError != nil {
-                showErrorAlert = true
+            Task { @MainActor in
+                if manager.lastError != nil {
+                    showErrorAlert = true
+                }
             }
         }
     }
 }
-
 

--- a/Routines/Views/EditRoutineView.swift
+++ b/Routines/Views/EditRoutineView.swift
@@ -80,6 +80,13 @@ struct EditRoutineView: View {
                 DatePicker("Time", selection: $tempRoutine.time, displayedComponents: .hourAndMinute)
                     .datePickerStyle(.compact)
                     .accessibilityLabel(Text("Routine time"))
+                Picker("Repeat", selection: $tempRoutine.repeatInterval) {
+                    ForEach(RoutineRepeatInterval.allCases) { interval in
+                        Text(interval.displayName).tag(interval)
+                    }
+                }
+                .pickerStyle(.menu)
+                .accessibilityHint(Text("Sets how often this routine repeats"))
                 EditDaysView(
                     days: Binding(
                         get: { tempRoutine.days },

--- a/Routines/Views/EditRoutineView.swift
+++ b/Routines/Views/EditRoutineView.swift
@@ -87,6 +87,26 @@ struct EditRoutineView: View {
                 }
                 .pickerStyle(.menu)
                 .accessibilityHint(Text("Sets how often this routine repeats"))
+                .onChange(of: tempRoutine.repeatIntervalRawValue) { oldRaw, newRaw in
+                    let oldInterval = RoutineRepeatInterval(rawValue: oldRaw) ?? .weekly
+                    let newInterval = RoutineRepeatInterval(rawValue: newRaw) ?? .weekly
+                    if newInterval.usesLongCycleStartDate && !oldInterval.usesLongCycleStartDate {
+                        tempRoutine.repeatAnchorDate = DateUtility.currentCalendar.startOfDay(for: Date())
+                    }
+                }
+                if tempRoutine.repeatInterval.usesLongCycleStartDate {
+                    DatePicker(
+                        "Start date",
+                        selection: $tempRoutine.repeatAnchorDate,
+                        displayedComponents: [.date]
+                    )
+                    .datePickerStyle(.compact)
+                    .accessibilityLabel(Text("Routine start date"))
+                    .accessibilityHint(Text("This routine stays hidden until this calendar day"))
+                    .onChange(of: tempRoutine.repeatAnchorDate) { _, newDate in
+                        tempRoutine.repeatAnchorDate = DateUtility.currentCalendar.startOfDay(for: newDate)
+                    }
+                }
                 EditDaysView(
                     days: Binding(
                         get: { tempRoutine.days },

--- a/Routines/Views/RoutineDetailView.swift
+++ b/Routines/Views/RoutineDetailView.swift
@@ -185,7 +185,9 @@ struct RoutineDetailView: View {
                     time: tempRoutine.time,
                     iconColor: tempRoutine.iconColor,
                     iconSymbol: tempRoutine.iconSymbol,
-                    days: routine.days
+                    days: routine.days,
+                    repeatInterval: tempRoutine.repeatInterval,
+                    repeatAnchorDate: tempRoutine.repeatAnchorDate
                 )
                 modelContext.delete(tempRoutine)
                 editRoutineViewIsPresented = false
@@ -273,4 +275,3 @@ struct RoutineDetailView: View {
         }
     }
 }
-

--- a/Routines/Views/Sheets/AddRoutineSheet.swift
+++ b/Routines/Views/Sheets/AddRoutineSheet.swift
@@ -24,6 +24,8 @@ struct AddRoutineSheet: View {
                     routine.time = tempRoutine.time
                     routine.iconSymbol = tempRoutine.iconSymbol
                     routine.iconColor = tempRoutine.iconColor
+                    routine.repeatInterval = tempRoutine.repeatInterval
+                    routine.repeatAnchorDate = tempRoutine.repeatAnchorDate
                     routine.days = tempRoutine.days
                 }
                 isPresented = false
@@ -32,5 +34,4 @@ struct AddRoutineSheet: View {
         }
     }
 }
-
 

--- a/Routines/Views/Sheets/EditRoutineSheet.swift
+++ b/Routines/Views/Sheets/EditRoutineSheet.swift
@@ -68,7 +68,9 @@ struct EditRoutineSheet: View {
                             time: tempRoutine.time,
                             iconColor: tempRoutine.iconColor,
                             iconSymbol: tempRoutine.iconSymbol,
-                            days: routine.days
+                            days: routine.days,
+                            repeatInterval: tempRoutine.repeatInterval,
+                            repeatAnchorDate: tempRoutine.repeatAnchorDate
                         )
                         modelContext.delete(tempRoutine)
                         isPresented = false
@@ -81,5 +83,4 @@ struct EditRoutineSheet: View {
         }
     }
 }
-
 

--- a/RoutinesTests/ModelTests/EditRoutineViewTests.swift
+++ b/RoutinesTests/ModelTests/EditRoutineViewTests.swift
@@ -12,12 +12,10 @@ import SwiftData
 
 @MainActor
 struct EditRoutineViewTests {
-    
+
     /// Tests that steps are displayed in correct order in edit mode
     @Test func stepsDisplayInCorrectOrder() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let routine = Routine(name: "Test Routine")
         context.insert(routine)
@@ -39,9 +37,7 @@ struct EditRoutineViewTests {
     
     /// Tests that step reordering updates order correctly
     @Test func stepReorderingUpdatesOrder() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let routine = Routine(name: "Test Routine")
         context.insert(routine)
@@ -69,9 +65,7 @@ struct EditRoutineViewTests {
     
     /// Tests that step deletion removes step and reorders remaining steps
     @Test func stepDeletionRemovesAndReorders() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let routine = Routine(name: "Test Routine")
         context.insert(routine)
@@ -101,9 +95,7 @@ struct EditRoutineViewTests {
     
     /// Tests that step deletion synchronizes routine days
     @Test func stepDeletionSynchronizesRoutineDays() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let monday = Weekday(rawValue: 2)
         let tuesday = Weekday(rawValue: 3)
@@ -136,9 +128,7 @@ struct EditRoutineViewTests {
     
     /// Tests that inline step name editing updates step name
     @Test func inlineStepNameEditingUpdatesName() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let routine = Routine(name: "Test Routine")
         context.insert(routine)
@@ -157,9 +147,7 @@ struct EditRoutineViewTests {
     
     /// Tests that all steps are shown in edit mode (not filtered by isToday)
     @Test func allStepsShownInEditMode() async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        let context = container.mainContext
+        let context = try UnitTestModelContainer.makeFreshContext()
         
         let monday = Weekday(rawValue: 2)
         let friday = Weekday(rawValue: 6)

--- a/RoutinesTests/ModelTests/RoutineDaySynchronizerTests.swift
+++ b/RoutinesTests/ModelTests/RoutineDaySynchronizerTests.swift
@@ -16,9 +16,7 @@ final class RoutineDaySynchronizerTests: XCTestCase {
     var synchronizer: RoutineDaySynchronizer!
     
     override func setUpWithError() throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try ModelContainer(for: Routine.self, Step.self, configurations: config)
-        modelContext = container.mainContext
+        modelContext = try UnitTestModelContainer.makeFreshContext()
         synchronizer = RoutineDaySynchronizer(modelContext: modelContext)
     }
     
@@ -32,14 +30,13 @@ final class RoutineDaySynchronizerTests: XCTestCase {
     private func createRoutine(days: [Weekday] = DateUtility.allWeekdays()) -> Routine {
         let routine = Routine(name: "Test Routine", days: days)
         modelContext.insert(routine)
-        routine.steps = []
         return routine
     }
     
     private func createStep(in routine: Routine, days: [Weekday]) -> Step {
         let step = Step(name: "Test Step", routine: routine, order: routine.steps?.count ?? 0, days: days)
         modelContext.insert(step)
-        routine.steps?.append(step)
+        routine.steps = (routine.steps ?? []) + [step]
         return step
     }
     
@@ -405,8 +402,8 @@ final class RoutineDaySynchronizerTests: XCTestCase {
         // Directly set step days that aren't in routine (simulating a data inconsistency)
         let step = Step(name: "Test", routine: routine, order: 0, days: [monday, wednesday, friday])
         modelContext.insert(step)
-        routine.steps?.append(step)
-        
+        routine.steps = (routine.steps ?? []) + [step]
+
         synchronizer.synchronizeRoutineDays(routine)
         
         XCTAssertTrue(routine.days.contains(monday))

--- a/RoutinesTests/ModelTests/RoutineRepeatIntervalActiveTests.swift
+++ b/RoutinesTests/ModelTests/RoutineRepeatIntervalActiveTests.swift
@@ -1,0 +1,96 @@
+//
+//  RoutineRepeatIntervalActiveTests.swift
+//  RoutinesTests
+//
+
+import Foundation
+import Testing
+@testable import Routines
+
+struct RoutineRepeatIntervalActiveTests {
+
+    private func date(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var components = DateComponents()
+        components.year = y
+        components.month = m
+        components.day = d
+        guard let date = Calendar.current.date(from: components) else {
+            Issue.record("Could not build date from components")
+            return Date()
+        }
+        return date
+    }
+
+    // MARK: - Month-based
+
+    @Test func monthlyMatchesEveryMonthFromAnchorMonth() {
+        let routine = Routine()
+        routine.repeatInterval = .monthly
+        routine.repeatAnchorDate = date(2024, 1, 15)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 1, 20)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 2, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2025, 6, 30)))
+    }
+
+    @Test func biMonthlyActiveOnlyOnEvenMonthOffsets() {
+        let routine = Routine()
+        routine.repeatInterval = .biMonthly
+        routine.repeatAnchorDate = date(2024, 1, 1)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 1, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 3, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 4, 1)) == false) // +3 months from Jan
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 5, 15)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 7, 1)))
+    }
+
+    @Test func quarterlyEveryThreeMonths() {
+        let routine = Routine()
+        routine.repeatInterval = .quarterly
+        routine.repeatAnchorDate = date(2024, 1, 1)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 1, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 4, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 2, 1)) == false)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 5, 1)) == false)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 7, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 10, 1)))
+    }
+
+    @Test func yearlyMatchesSameMonthEachYear() {
+        let routine = Routine()
+        routine.repeatInterval = .yearly
+        routine.repeatAnchorDate = date(2024, 3, 10)
+        #expect(routine.isRepeatIntervalActive(on: date(2024, 3, 10)))
+        #expect(routine.isRepeatIntervalActive(on: date(2025, 3, 1)))
+        #expect(routine.isRepeatIntervalActive(on: date(2025, 9, 10)) == false)
+    }
+
+    // MARK: - Week-based (regression)
+
+    @Test func weeklyEveryWeek() {
+        let routine = Routine()
+        routine.repeatInterval = .weekly
+        let anchor = date(2024, 6, 3)
+        routine.repeatAnchorDate = anchor
+        #expect(routine.isRepeatIntervalActive(on: anchor))
+        guard let oneWeekLater = Calendar.current.date(byAdding: .day, value: 7, to: anchor) else {
+            Issue.record("date math failed")
+            return
+        }
+        #expect(routine.isRepeatIntervalActive(on: oneWeekLater))
+    }
+
+    @Test func fortnightlySkipsEveryOtherWeek() {
+        let routine = Routine()
+        routine.repeatInterval = .fortnightly
+        let anchor = date(2024, 6, 3)
+        routine.repeatAnchorDate = anchor
+        guard let oneWeekLater = Calendar.current.date(byAdding: .day, value: 7, to: anchor),
+              let twoWeeksLater = Calendar.current.date(byAdding: .day, value: 14, to: anchor) else {
+            Issue.record("date math failed")
+            return
+        }
+        #expect(routine.isRepeatIntervalActive(on: anchor))
+        #expect(routine.isRepeatIntervalActive(on: oneWeekLater) == false)
+        #expect(routine.isRepeatIntervalActive(on: twoWeeksLater))
+    }
+}

--- a/RoutinesTests/ModelTests/RoutineStartDateSchedulingTests.swift
+++ b/RoutinesTests/ModelTests/RoutineStartDateSchedulingTests.swift
@@ -1,0 +1,93 @@
+//
+//  RoutineStartDateSchedulingTests.swift
+//  RoutinesTests
+//
+
+import Foundation
+import Testing
+@testable import Routines
+
+struct RoutineStartDateSchedulingTests {
+
+    private func date(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var components = DateComponents()
+        components.year = y
+        components.month = m
+        components.day = d
+        guard let date = Calendar.current.date(from: components) else {
+            Issue.record("Could not build date from components")
+            return Date()
+        }
+        return date
+    }
+
+    @Test func longCycleIntervalsUseExplicitStartDate() {
+        #expect(RoutineRepeatInterval.weekly.usesLongCycleStartDate == false)
+        #expect(RoutineRepeatInterval.fortnightly.usesLongCycleStartDate == true)
+        #expect(RoutineRepeatInterval.monthly.usesLongCycleStartDate == true)
+        #expect(RoutineRepeatInterval.biMonthly.usesLongCycleStartDate == true)
+        #expect(RoutineRepeatInterval.quarterly.usesLongCycleStartDate == true)
+        #expect(RoutineRepeatInterval.yearly.usesLongCycleStartDate == true)
+    }
+
+    @Test func monthlyNotScheduledBeforeStartDate() {
+        let routine = Routine()
+        routine.repeatInterval = .monthly
+        routine.repeatAnchorDate = date(2024, 6, 15)
+        // Tuesday June 11, 2024 — calendar weekday 3 (Apple: Tue)
+        routine.days = [Weekday(rawValue: 3)]
+
+        #expect(routine.isScheduled(on: date(2024, 6, 11)) == false)
+
+        // Tuesday June 18, 2024 — same month as anchor, after start
+        #expect(routine.isScheduled(on: date(2024, 6, 18)) == true)
+    }
+
+    @Test func monthlyScheduledOnStartDay() {
+        let routine = Routine()
+        routine.repeatInterval = .monthly
+        routine.repeatAnchorDate = date(2024, 6, 15)
+        // Saturday June 15, 2024 — weekday 7
+        routine.days = [Weekday(rawValue: 7)]
+
+        #expect(routine.isScheduled(on: date(2024, 6, 15)) == true)
+    }
+
+    @Test func fortnightlyNotScheduledBeforeStartDateEvenWhenPhaseMatches() {
+        let routine = Routine()
+        routine.repeatInterval = .fortnightly
+        let anchor = date(2024, 6, 15)
+        routine.repeatAnchorDate = anchor
+        routine.days = DateUtility.allWeekdays()
+
+        // Before anchor
+        #expect(routine.isScheduled(on: date(2024, 6, 10)) == false)
+        // On or after anchor, still must match weekday + biweekly pattern
+        #expect(routine.isScheduled(on: anchor) == true)
+    }
+
+    @Test func weeklyIgnoresStartDateGate() {
+        let routine = Routine()
+        routine.repeatInterval = .weekly
+        routine.repeatAnchorDate = date(2030, 1, 1)
+        let weekday = DateUtility.weekday(for: date(2024, 6, 11))
+        routine.days = [weekday]
+
+        #expect(routine.isScheduled(on: date(2024, 6, 11)) == true)
+    }
+
+    @Test func stepInactiveBeforeRoutineStartDate() {
+        let routine = Routine()
+        routine.repeatInterval = .monthly
+        routine.repeatAnchorDate = date(2024, 6, 15)
+        let w = Weekday(rawValue: 3)
+        routine.days = [w]
+
+        let step = Step(name: "A", routine: routine, order: 0, days: [w])
+        routine.steps = [step]
+        step.routine = routine
+
+        #expect(step.isActive(on: date(2024, 6, 11)) == false)
+        #expect(step.isActive(on: date(2024, 6, 18)) == true)
+    }
+}

--- a/RoutinesTests/ModelTests/WatchOSFunctionalityTests.swift
+++ b/RoutinesTests/ModelTests/WatchOSFunctionalityTests.swift
@@ -67,17 +67,16 @@ struct WatchOSFunctionalityTests {
     /// Tests that steps can be added to a routine with correct ordering
     @Test func addingStepsToRoutine() async throws {
         let routine = Routine(name: "Test Routine")
-        routine.steps = []
         
         // Add first step
         let step1 = Step(name: "First Step", routine: routine, order: 0)
-        routine.steps?.append(step1)
+        routine.steps = [step1]
         #expect((routine.steps ?? []).count == 1)
         #expect(routine.steps?[0].order == 0)
         
         // Add second step
         let step2 = Step(name: "Second Step", routine: routine, order: 1)
-        routine.steps?.append(step2)
+        routine.steps = [step1, step2]
         #expect((routine.steps ?? []).count == 2)
         #expect(routine.steps?[1].order == 1)
         


### PR DESCRIPTION
### Motivation
- Routines were constrained to weekly-only schedules, and the product requires support for longer repeat intervals (fortnightly, monthly, bi‑monthly, quarterly, yearly). 
- Provide a way for users to select repeat cadence in the routine edit flow and for the scheduling logic to respect those intervals when evaluating "is today" for routines and steps. 

### Description
- Add a new `RoutineRepeatInterval` enum (`Routines/Models/RoutineRepeatInterval.swift`) enumerating `weekly`, `fortnightly`, `monthly`, `biMonthly`, `quarterly`, and `yearly` with user-friendly display names and interval helpers. 
- Persist repeat settings on `Routine` by adding `repeatIntervalRawValue` and `repeatAnchorDate`, exposing a computed `repeatInterval` property, and extending initializers and `copy()` to include these fields (`Routines/Models/Routine.swift`). 
- Implement interval-aware scheduling helpers: `DateUtility.weekday(for:)` and `Routine.isRepeatIntervalActive(on:)` plus `isScheduled(on:)` to determine whether a routine applies on a given date, and update `Routine.isToday()` and `Step.isToday()` to respect the routine repeat interval (`Routines/Utilities/DateUtility.swift`, `Routines/Models/Routine.swift`, `Routines/Models/Step.swift`). 
- Surface the choice in the UI and persist it through save flows by adding a `Picker` to `EditRoutineView`, and passing/storing the values in add/edit sheets and the manager `createRoutine`/`updateRoutine` APIs (`Routines/Views/EditRoutineView.swift`, `Routines/Views/Sheets/AddRoutineSheet.swift`, `Routines/Views/Sheets/EditRoutineSheet.swift`, `Routines/Views/RoutineDetailView.swift`, `Routines/Services/RoutineManager.swift`).

### Testing
- No automated tests were executed as part of this change (no CI/test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b51a0e108332bc1e45a914248543)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scheduling semantics for which routines/steps are considered active today and adds new persisted fields, which could affect existing user schedules if the interval calculations or defaults are off.
> 
> **Overview**
> Adds **repeat cadence support** for routines beyond weekly by introducing `RoutineRepeatInterval` and persisting `repeatInterval`/`repeatAnchorDate` on `Routine`.
> 
> Updates scheduling logic so `Routine.isToday()`/`Step.isToday()` only consider items active when both the weekday matches and the configured week/month interval matches relative to the anchor date, and threads the new fields through routine create/update flows.
> 
> Surfaces the setting in the UI via a new *Repeat* picker in `EditRoutineView`, and ensures add/edit/save sheets persist the chosen interval and anchor date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7860136865d85de0db72959e57c50c6798f7e029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->